### PR TITLE
apt-transport-https

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -27,6 +27,7 @@ class kibana::install {
     case $::osfamily {
       'Debian': {
         include ::apt
+        Class['apt::update'] -> Package['kibana']
 
         apt::source { 'kibana':
           ensure   => $_ensure,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -27,10 +27,6 @@ class kibana::install {
     case $::osfamily {
       'Debian': {
         include ::apt
-        package { 'apt-transport-https' :
-          before => Class['apt::update'],
-        }
-        Class['apt::update'] -> Package['kibana']
 
         apt::source { 'kibana':
           ensure   => $_ensure,

--- a/spec/acceptance/nodesets/debian-7-x64.yml
+++ b/spec/acceptance/nodesets/debian-7-x64.yml
@@ -9,4 +9,5 @@ HOSTS:
     docker_container_name: debian-7-amd64
     docker_preserve_image: true
     docker_image_commands:
-      - apt-get install -yq wget
+      - apt-get update
+      - apt-get install -yq libssl-dev apt-transport-https wget

--- a/spec/acceptance/nodesets/debian-8-x64.yml
+++ b/spec/acceptance/nodesets/debian-8-x64.yml
@@ -9,6 +9,7 @@ HOSTS:
     docker_container_name: debian-8-amd64
     docker_preserve_image: true
     docker_image_commands:
-      - apt-get install -yq wget
+      - apt-get update
+      - apt-get install -yq libssl-dev apt-transport-https wget
       - rm /lib/systemd/system/systemd*udev*
       - rm /lib/systemd/system/getty.target

--- a/spec/acceptance/nodesets/ubuntu-1204-x64.yml
+++ b/spec/acceptance/nodesets/ubuntu-1204-x64.yml
@@ -9,6 +9,8 @@ HOSTS:
     docker_container_name: ubuntu-1204-amd64
     docker_preserve_image: true
     docker_image_commands:
+      - apt-get update
+      - apt-get install -yq libssl-dev apt-transport-https
       - ln -sf /sbin/initctl.distrib /sbin/initctl
       - locale-gen en_US en_US.UTF-8
       - dpkg-reconfigure locales

--- a/spec/acceptance/nodesets/ubuntu-1404-x64.yml
+++ b/spec/acceptance/nodesets/ubuntu-1404-x64.yml
@@ -9,6 +9,8 @@ HOSTS:
     docker_container_name: ubuntu-1404-amd64
     docker_preserve_image: true
     docker_image_commands:
+      - apt-get update
+      - apt-get install -yq libssl-dev apt-transport-https
       - ln -sf /sbin/initctl.distrib /sbin/initctl
       - locale-gen en_US en_US.UTF-8
       - dpkg-reconfigure locales

--- a/spec/acceptance/nodesets/ubuntu-1604-x64.yml
+++ b/spec/acceptance/nodesets/ubuntu-1604-x64.yml
@@ -9,5 +9,7 @@ HOSTS:
     docker_container_name: ubuntu-1604-amd64
     docker_preserve_image: true
     docker_image_commands:
+      - apt-get update
+      - apt-get install -yq libssl-dev apt-transport-https
       - locale-gen en_US en_US.UTF-8
       - dpkg-reconfigure locales

--- a/spec/classes/kibana_spec.rb
+++ b/spec/classes/kibana_spec.rb
@@ -53,11 +53,6 @@ describe 'kibana', :type => 'class' do
             describe "#{facts[:osfamily]} resources" do
               case facts[:osfamily]
               when 'Debian'
-                it { is_expected.to contain_class('apt') }
-                it 'installs TLS support before updating the package cache' do
-                  is_expected.to contain_package('apt-transport-https')
-                    .that_comes_before('Class[apt::update]')
-                end
                 it 'updates package cache before installing kibana' do
                   is_expected.to contain_class('apt::update')
                     .that_comes_before('Package[kibana]')


### PR DESCRIPTION
declaring the apt-transport-https package may cause a duplicate resource declaration:

`Error: Evaluation Error: Error while evaluating a Function Call, Duplicate declaration: Package[apt-transport-https] is already declared`

there is a dependency cycle when trying to order apt-transport-https before apt_update (as keys/sources are ordered before apt_update which is ordered before apt install for new packages, causing apt_update to fail since the https source is already added). 

Since the $required_packages parameter in the apt module is deprecated, this package should be already installed in the system.


Pull request acceptance prerequisites:

- [X] Signed the [CLA](https://www.elastic.co/contributor-agreement/) (if not already signed)
- [X] Rebased/up-to-date with base branch
- [X] Updated CHANGELOG.md with patch notes (if necessary)
- [X] Any relevant docs (README.markdown or inline documentation) updated (if necessary)
- [X] Updated CONTRIBUTORS (if you would like attribution)
- [ ] Tests pass CI
