### PR TITLE
Allow to specify package version and revision for ensure parameter

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -79,6 +79,12 @@ In order to explicitly ensure that version 5.2.0 of Kibana is installed:
 class { 'kibana': ensure => '5.2.0' }
 ```
 
+Package revisions are supported too:
+
+```puppet
+class { 'kibana': ensure => '5.2.2-1' }
+```
+
 The `kibana` class also supports removal through use of `ensure => absent`:
 
 ```puppet

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -28,7 +28,7 @@
 # @param repo_version Repository major version to use
 #
 class kibana (
-  Variant[Enum['present', 'absent', 'latest'], Pattern[/^\d([.]\d+)*(-[\d+\w+])$/]] $ensure          = 'present',
+  Variant[Enum['present', 'absent', 'latest'], Pattern[/^\d([.]\d+)*(-[\d\w]+)?$/]] $ensure          = 'present',
   Hash[String[1], Variant[String[1], Integer, Boolean, Array]]           $config          = {},
   Boolean                                                                $manage_repo     = true,
   String                                                                 $repo_key_id     = '46095ACC8548582C1A2699A9D27D666CD88E42B4',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -28,7 +28,7 @@
 # @param repo_version Repository major version to use
 #
 class kibana (
-  Variant[Enum['present', 'absent', 'latest'], Pattern[/^\d([.]\d+)*$/]] $ensure          = 'present',
+  Variant[Enum['present', 'absent', 'latest'], Pattern[/^\d([.]\d+)*(-[\d+\w+])$/]] $ensure          = 'present',
   Hash[String[1], Variant[String[1], Integer, Boolean, Array]]           $config          = {},
   Boolean                                                                $manage_repo     = true,
   String                                                                 $repo_key_id     = '46095ACC8548582C1A2699A9D27D666CD88E42B4',

--- a/spec/classes/kibana_spec.rb
+++ b/spec/classes/kibana_spec.rb
@@ -152,7 +152,7 @@ describe 'kibana', :type => 'class' do
         describe 'parameter validation for' do
           describe 'ensure' do
             context 'valid parameter' do
-              %w(present absent latest 5.2.1 5.2.2-1).each do |param|
+              %w(present absent latest 5.2.1 5.2.2-1 5.2.2-bpo1).each do |param|
                 context param do
                   let(:params) { { :ensure => param } }
                   it { should compile.with_all_deps }

--- a/spec/classes/kibana_spec.rb
+++ b/spec/classes/kibana_spec.rb
@@ -152,7 +152,7 @@ describe 'kibana', :type => 'class' do
         describe 'parameter validation for' do
           describe 'ensure' do
             context 'valid parameter' do
-              %w(present absent latest 5.2.1).each do |param|
+              %w(present absent latest 5.2.1 5.2.2-1).each do |param|
                 context param do
                   let(:params) { { :ensure => param } }
                   it { should compile.with_all_deps }


### PR DESCRIPTION
First of all, thanks for starting your work on an official Puppet module. I've been previously using https://github.com/Nextdoor/puppet-kibana5 but am in progress migrating over here.

One thing I need to ensure is that the Kibana version is pinned. That version is used to determine the correct Elasticsearch API call for storing Kibana config, i.e. the default index (from filebeat, icingabeat, or anything else).

In order to achieve that, I'll also need to specify the exact package revision inside the version string on yum based systems.

Currently the regex checking for valid parameter values does not allow for that. I have modified and tested it working on CentOS7 by using a Vagrant box to install Elastic Stack using the official modules. Puppet version: 3.8.7

CLA is signed.

<!--

The following list of checkboxes are the prerequisites for getting your contribution accepted.
Please check them as they are completed.

-->

Pull request acceptance prerequisites:

- [x] Signed the [CLA](https://www.elastic.co/contributor-agreement/) (if not already signed)
- [x] Rebased/up-to-date with base branch
- [ ] Updated CHANGELOG.md with patch notes (if necessary)
- [x] Any relevant docs (README.markdown or inline documentation) updated (if necessary)
- [ ] Updated CONTRIBUTORS (if you would like attribution)
- [x] Tests pass CI
