### PR TITLE
service: Added service status option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## x.x.x (Month Day, 2017)
 
 #### Features
+* Added support for service status
 
 ## 5.1.0 (August 18, 2017)
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -27,6 +27,7 @@
 # @param repo_priority [Integer] Optional repository priority
 # @param repo_proxy [String] Proxy to use for repository access (yum only)
 # @param repo_version [String] Repository major version to use
+# @param status [String] Service status ('enabled', 'disabled', 'running', 'unmanaged')
 #
 class kibana (
   $ensure          = 'present',
@@ -38,6 +39,7 @@ class kibana (
   $repo_priority   = undef,
   $repo_proxy      = undef,
   $repo_version    = '5.x',
+  $status          = 'enabled',
 ) {
 
   anchor {'kibana::begin': }
@@ -66,6 +68,10 @@ class kibana (
 
   if !($repo_version in ['5.x']) and $repo_version !~ /^4\.(1|[4-6])$/ {
     fail('Invalid value for repo_version')
+  }
+
+  if ! ($status in ['enabled', 'disabled', 'running', 'unmanaged']) {
+    fail('Invalid value for status')
   }
 
   class { '::kibana::install': }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -5,8 +5,38 @@
 #
 class kibana::service {
 
-  $_ensure = $::kibana::ensure != 'absent'
-  $_enable = $::kibana::ensure != 'absent'
+  if $::kibana::ensure != 'absent' {
+    case $::kibana::status {
+      # Stop service and disable on boot
+      'disabled': {
+        $_ensure = false
+        $_enable = false
+      }
+      # Start service and enable on boot
+      'enabled': {
+        $_ensure = true
+        $_enable = true
+      }
+      # Start service and disable on boot
+      'running': {
+        $_ensure = true
+        $_enable = false
+      }
+      # Ignore current state and disable on boot
+      'unmanaged': {
+        $_ensure = undef
+        $_enable = false
+      }
+      # Unknown status
+      default: {
+        fail('Invalid value for status')
+      }
+    }
+  } else {
+    # The package will be removed
+    $_ensure = false
+    $_enable = false
+  }
 
   service { 'kibana':
     ensure => $_ensure,


### PR DESCRIPTION
Added the option to set the service to one of 'enabled', 'disabled',
'running' or 'unmanaged' values. The possible values and behaviour are
taken from the elastic-elasticsearch module.

<!--

The following list of checkboxes are the prerequisites for getting your contribution accepted.
Please check them as they are completed.

-->

Pull request acceptance prerequisites:

- [x] Signed the [CLA](https://www.elastic.co/contributor-agreement/) (if not already signed)
- [x] Rebased/up-to-date with base branch
- [x] Updated CHANGELOG.md with patch notes (if necessary)
- [ ] Any relevant docs (README.markdown or inline documentation) updated (if necessary)
- [ ] Updated CONTRIBUTORS (if you would like attribution)
- [x] Tests pass CI
