### PR TITLE
Fix plugin install failure due to outdated CA bundle

### DIFF
--- a/spec/acceptance/tests/class_v5_spec.rb
+++ b/spec/acceptance/tests/class_v5_spec.rb
@@ -32,8 +32,11 @@ describe 'kibana class v5' do
     MANIFEST
   end
 
-  let(:plugin_url) do
-    "https://github.com/DeanF/#{plugin}/releases/download/v#{plugin_version}/#{plugin}-#{version.split('-').first}.zip"
+  let(:plugin_url) { "file:///tmp/#{plugin}-#{plugin_version}.zip" }
+
+  before do
+    source = "https://github.com/DeanF/#{plugin}/releases/download/v#{plugin_version}/#{plugin}-#{version.split('-').first}.zip"
+    on default, "curl -fsSL -o /tmp/#{plugin}-#{plugin_version}.zip #{source}"
   end
 
   include_examples 'class manifests',


### PR DESCRIPTION
#### Pull Request (PR) description
While trying to run acceptance tests, the Kibana module was failing its tests when attempting to transfer the Kibana package from GitHub.

After trying it manually at the terminal, it seems like the issue is that the CA at GitHub is not trusted by the CA bundle in the old Kibana package. This leads to "unable to get local issuer certificate" errors, despite the URL being valid and reachable by curl.

This fix pre-downloads the plugin using curl, then passes it with `file://` to the manifest instead. This avoids the CA check but still downloads the right plugin for the tests.

#### This Pull Request (PR) fixes the following issues
n/a